### PR TITLE
Update Venues “2024/12-20/nistep-public-online-symposium/readme”

### DIFF
--- a/content/venues/2024/12-20/nistep-public-online-symposium/readme.md
+++ b/content/venues/2024/12-20/nistep-public-online-symposium/readme.md
@@ -1,12 +1,13 @@
 ---
 dateStart: 2024-12-20T01:00:26.706Z
 dateEnd: 2024-12-20T06:00:11.513Z
-title: NISTEP Public Online Symposium
+title: '"Places & Spaces: Mapping Science" at NISTEP Public Online Symposium'
 venue: National Institute of Science and Technology Policy (NISTEP)
 organizer: Sakai Tomoko
+credit: "https://www.youtube.com/live/ylLz_n-VmCg?si=sOlQ3212zE5iICcm "
 city: NISTEP
 state: Tokyo
 country: Japan
-pdfLink: pubulic_online_symposuium1220_e.pdf
+pdfLink: https://www.nistep.go.jp/wp/wp-content/uploads/pubulic_online_symposuium1220_e.pdf
 venueImages: []
 ---


### PR DESCRIPTION
Title change: 
'Places & Spaces: Mapping Science" at NISTEP Public Online Symposium

Links added:
Under Credit: https://www.youtube.com/live/ylLz_n-VmCg?si=sOlQ3212zE5iICcm 

Under PDF Link: https://www.nistep.go.jp/wp/wp-content/uploads/pubulic_online_symposuium1220_e.pdf 