### PR TITLE
Updates to maps and macroscope information/links

### DIFF
--- a/content/macroscope/12/4/readme.md
+++ b/content/macroscope/12/4/readme.md
@@ -17,9 +17,6 @@ en:
     flow of jet fuel and agricultural commodities around the globe, track a
     fleet of cruise ships in real time, or monitor traffic at ports around the
     world.  
-      
-    Learn more about _FleetMon Explorer_ at
-    [http://www.fleetmon.com/services/live-tracking/fleetmon-explorer](http://www.fleetmon.com/services/live-tracking/fleetmon-explorer).
   makers:
     - fleetmon/readme
   year: 2016
@@ -36,6 +33,5 @@ en:
     sm: image.sm.jpg
     med: image.med.jpg
     lg: image.lg.jpg
-  externalLink: 'http://www.fleetmon.com/services/live-tracking/fleetmon-explorer'
   videoLink: 'https://demo.cns.iu.edu/macroscope-kiosk-13/macroscopes/fleetmon.webm'
 ---

--- a/content/macroscope/13/4/readme.md
+++ b/content/macroscope/13/4/readme.md
@@ -26,7 +26,7 @@ en:
 
 
     Visit Science Paths online at
-    [http://kimalbrecht.com/project/science-paths](http://kimalbrecht.com/project/science-paths).
+    [https://sciencepaths.kimalbrecht.com/](https://sciencepaths.kimalbrecht.com/).
   makers:
     - kim-albrecht/readme
     - albert-laszlo-barabasi/readme

--- a/content/macroscope/15/1/readme.md
+++ b/content/macroscope/15/1/readme.md
@@ -29,12 +29,6 @@ en:
     Migrants_ data set to visualize causes of death for those en route. A third
     data set connects adverse outcomes upon arrival with news stories of
     struggles faced by migrants.
-
-      
-
-    _Refugee Flow_ and its companion website can be found at
-    [http://refugeeflow.world/landing](http://refugeeflow.world/landing
-    "Macroscope: Refugee Flow").
   makers:
     - abin-abraham/readme
     - will-jiahao-su/readme
@@ -49,6 +43,5 @@ en:
     sm: image.sm.jpg
     med: image.med.jpg
     lg: image.lg.jpg
-  externalLink: 'http://refugeeflow.world/landing'
   videoLink: 'https://demo.cns.iu.edu/macroscope-kiosk-13/macroscopes/RefugeeFlow.webm'
 ---

--- a/content/macroscope/16/2/readme.md
+++ b/content/macroscope/16/2/readme.md
@@ -25,9 +25,8 @@ en:
 
       
 
-    Watson News Explorer can be found at
-    [https://news-explorer.mybluemix.net/](https://news-explorer.mybluemix.net/
-    "Link to Watson News Explorer macroscope").
+    A narrated demonstration of the Watson News Explorer can be viewed at [https://youtu.be/aGUYoXoo1iM?si=oScO7w_IFHWDJ1Ty](https://youtu.be/aGUYoXoo1iM?si=oScO7w_IFHWDJ1Ty).
+
   makers:
     - steven-ross/readme
     - tim-stutts/readme
@@ -45,6 +44,5 @@ en:
     sm: image.sm.jpg
     med: image.med.jpg
     lg: image.lg.jpg
-  externalLink: 'https://news-explorer.mybluemix.net/'
   videoLink: 'https://demo.cns.iu.edu/macroscope-kiosk-13/macroscopes/WatsonNewsExplorer.webm'
 ---

--- a/content/map/3/8/readme.md
+++ b/content/map/3/8/readme.md
@@ -22,9 +22,7 @@ en:
     (bottom right), and the number of times other articles link to an article
     (bottom left). These visualizations serve to highlight current trends and
     predict future editing activity and growth in Wikipedia articles related to
-    science, technology, and mathematics. Interactive Wikipedia maps are
-    available at
-    [http://scimaps.org/web/maps/wikipedia/](http://scimaps.org/web/maps/wikipedia/).
+    science, technology, and mathematics.
   makers:
     - elisha-f-h-allgood/readme
     - bruce-w-herr-ii/readme

--- a/content/map/7/9/readme.md
+++ b/content/map/7/9/readme.md
@@ -8,7 +8,7 @@ en:
     visualization, information aesthetics, and user interface design. This
     visualization depicts the classification taxonomy developed and used in the
     MACE project
-    ([http://portal.mace-project.eu](http://portal.mace-project.eu)), which aims
+    ([https://www.mace-project.eu/](https://www.mace-project.eu/)), which aims
     at providing better access to digital resources for teaching and learning
     about architecture. It shows a bird’s-eye view of the hierarchical structure
     of over 2,800 terms for tagging resources. Most of the terms exist in
@@ -18,11 +18,7 @@ en:
     for each concept, providing hints about the usage patterns of the taxonomy.
     For the subject matter experts in the project, visualizations like these
     have shown to be useful for quality control and iterative refinements of the
-    taxonomy. For end users, an interactive version of the diagram is available
-    on the MACE portal
-    ([http://portal.mace-project.eu/BrowseByClassification](http://portal.mace-project.eu/BrowseByClassification)),
-    which allows one to search and browse thousands of resources in an
-    interactive visual refinement process.
+    taxonomy.
   makers:
     - moritz-stefaner/readme
   year: 2011

--- a/content/map/8/3/readme.md
+++ b/content/map/8/3/readme.md
@@ -16,9 +16,7 @@ en:
     imagine yourself in another time and place, to uncover treasures, and to be
     part of the big picture. Go hunt for details and learn fun facts about the
     collection. Last but not least, make sure you and your parents visit the
-    parts you really want to see. The map is available for free at all Museum
-    information desks and online at
-    [http://metmuseum.org/learn/for-kids](http://metmuseum.org/learn/for-kids)
+    parts you really want to see.
   makers:
     - masha-turchinsky/readme
     - john-kerschbaum/readme

--- a/content/map/8/7/readme.md
+++ b/content/map/8/7/readme.md
@@ -20,8 +20,7 @@ en:
     “cloud” of pages) and which appear much more rarely (bottom and left parts).
     If you are a beginning manga artist and want to establish a unique style,
     you may want to position yourself in either of these areas, which so far
-    have not been explored by other artists. To learn more, visit
-    [http://softwarestudies.com](http://softwarestudies.com)
+    have not been explored by other artists.
   makers:
     - lev-manovich/readme
     - jeremy-douglass/readme

--- a/content/map/9/1/readme.md
+++ b/content/map/9/1/readme.md
@@ -24,9 +24,7 @@ en:
     scientific questions. In the particular model-data synthesis used for this
     visualization, only the larger, ocean basin-wide scales have been adjusted
     to fit observations. Smaller-scale ocean currents are free to evolve on
-    their own according to the computer model's equations. To experience this
-    unforgettable view of oceanic circulation in action, go to
-    [http://www.nasa.gov/topics/earth/features/perpetual-ocean.html](http://www.nasa.gov/topics/earth/features/perpetual-ocean.html).
+    their own according to the computer model's equations.
   makers:
     - dimitris-menemenlis/readme
     - horace-g-mitchell/readme

--- a/content/map/9/8/readme.md
+++ b/content/map/9/8/readme.md
@@ -23,9 +23,7 @@ en:
     predefined number of incoming links are included, in addition to peripheral
     articles that have a direct link to them. To animate the evolution of the
     English Wikipedia network, living people articles were collected and
-    analysed for different points in time. To explore the networks
-    interactively, visit
-    [http://www.ickn.org/wikimaps](http://www.ickn.org/wikimaps).
+    analysed for different points in time.
   makers:
     - peter-a-gloor/readme
     - keiichi-nemoto/readme

--- a/website/projects/scimaps/src/app/core/components/header/header.component.scss
+++ b/website/projects/scimaps/src/app/core/components/header/header.component.scss
@@ -31,6 +31,10 @@
     padding: 0 1.5rem;
   }
 
+  .nav-item {
+    cursor: pointer;
+  }
+
   .nav-item.exhibit, .nav-item.contact, .nav-item {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Macroscopes


1. https://scimaps.org/macroscope/16/2 Watson News Explorer
 Remove ‘Watson News Explorer can be found at[ https://news-explorer.mybluemix.net/](https://news-explorer.mybluemix.net/).’
Replace with ‘A narrated demonstration of the Watson News Explorer can be viewed at https://youtu.be/aGUYoXoo1iM?si=oScO7w_IFHWDJ1Ty’ 
Remove https://news-explorer.mybluemix.net/ under ‘External Link (optional)’

2. https://scimaps.org/macroscope/15/1 Refugee Flow
Remove ‘Refugee Flow and its companion website can be found at[ http://refugeeflow.world/landing](http://refugeeflow.world/landing).’
Remove http://refugeeflow.world/landing under ‘External Link (optional)’

3. https://scimaps.org/macroscope/13/4 Science Paths
Remove ‘http://kimalbrecht.com/project/science-paths’
Replace with ‘https://sciencepaths.kimalbrecht.com/’ 

4. https://scimaps.org/macroscope/12/4 FleetMon Explorer
Remove ‘Learn more about FleetMon Explorer at[ http://www.fleetmon.com/services/live-tracking/fleetmon-explorer](http://www.fleetmon.com/services/live-tracking/fleetmon-explorer).’
Remove http://www.fleetmon.com/services/live-tracking/fleetmon-explorer from ‘External Link (optional)’

Maps

1. https://scimaps.org/map/9/1 NASA Views Our Perpetually Moving Oceans
Remove ‘To experience this unforgettable view of oceanic circulation in action, go to http://www.nasa.gov/topics/earth/features/perpetual-ocean.html.’

2. https://scimaps.org/map/9/8 Who Really Matters in the World—Leadership Networks in Different-Language Wikipedias 
Remove ‘To explore the networks interactively, visit http://www.ickn.org/wikimaps.’

3. https://scimaps.org/map/8/3 Metropolitan Museum of Art Family Map 
Remove ‘The map is available for free at all Museum information desks and online at http://metmuseum.org/learn/for-kids’ 

4. https://scimaps.org/map/8/7 Manga Universe
Remove ‘To learn more, visit http://softwarestudies.com/’ 

5. https://scimaps.org/map/7/9 MACE Classification Taxonomy
Remove ‘http://portal.mace-project.eu/’ 
Replace with ‘https://www.mace-project.eu/’
Remove ‘For end users, an interactive version of the diagram is available on the MACE portal (http://portal.mace-project.eu/BrowseByClassification), which allows one to search and browse thousands of resources in an interactive visual refinement process.’

6. https://scimaps.org/map/3/8 Science-Related Wikipedian Activity
Remove ‘Interactive Wikipedia maps are available at http://scimaps.org/web/maps/wikipedia/.’