### PR TITLE
Scimaps Books Updates

### DIFF
--- a/content/book/atlas-of-forecasts-modeling-and-mapping-desirable-futures/readme.md
+++ b/content/book/atlas-of-forecasts-modeling-and-mapping-desirable-futures/readme.md
@@ -5,7 +5,7 @@ author:
   - katy-borner/readme
 publisher: MIT Press
 pdfLink: atlas-of-forecasts.pdf
-amazonLink: https://mitpress.mit.edu/9780262045957/atlas-of-forecasts/
+amazonLink: https://www.amazon.com/dp/0262045958/
 bookImages:
   - sm: image01.med.jpg
     lg: image01.lg.jpg

--- a/content/book/atlas-of-knowledge-anyone-can-map/readme.md
+++ b/content/book/atlas-of-knowledge-anyone-can-map/readme.md
@@ -19,7 +19,7 @@ author:
   - katy-borner/readme
 publisher: MIT Press
 pdfLink: atlas-of-knowledge.pdf
-amazonLink: https://mitpress.mit.edu/9780262028813/atlas-of-knowledge/
+amazonLink: https://www.amazon.com/dp/0262028816/
 ---
 In an age of information overload, the ability to make sense of vast amounts of data and to render insightful visualizations is as important as the ability to read and write. The *Atlas of Knowledge* explains and exemplifies the power of visualizations not only to help locate us in physical space but also to help us understand the extent and structure of our collective knowledge, to identify bursts of activity, pathways of ideas, and borders that beg to be crossed.\
 \

--- a/content/book/atlas-of-macroscopes-interactive-data-visualizations/readme.md
+++ b/content/book/atlas-of-macroscopes-interactive-data-visualizations/readme.md
@@ -19,7 +19,7 @@ author:
   - todd-theriault/readme
 publisher: MIT Press
 pdfLink: Atlas-of-Macroscopes-Excerpts.pdf
-amazonLink: https://mitpress.mit.edu/9780262049924/atlas-of-macroscopes/
+amazonLink: https://www.amazon.com/dp/0262049929/
 ---
 **A fascinating data adventure through the lens of macroscopes, which offer us illuminating and holistic views of our ever-changing world.**
 

--- a/content/book/atlas-of-science-visualizing-what-we-know/readme.md
+++ b/content/book/atlas-of-science-visualizing-what-we-know/readme.md
@@ -17,7 +17,7 @@ author:
   - katy-borner/readme
 publisher: MIT Press
 pdfLink: atlas-of-science.pdf
-amazonLink: https://mitpress.mit.edu/9780262014458/atlas-of-science/
+amazonLink: https://www.amazon.com/dp/0262014459/
 ---
 *Atlas of Science*, based on the popular exhibit *Places & Spaces: Mapping Science*, describes and displays successful mapping techniques. The heart of the book is a visual feast: Claudius Ptolemy's Cosmographia World Map from 1482; a guide to a PhD thesis that resembles a subway map; "the structure of science" as revealed in a map of citation relationships in papers published in 2002; a periodic table; and many more. Each entry includes the story behind the map and biographies of its makers.\
 \


### PR DESCRIPTION
Put in links to the Amazon buy link for all 4

<img width="429" height="160" alt="Screenshot 2025-08-28 at 12 32 40 PM" src="https://github.com/user-attachments/assets/1ddd50de-6c69-47da-a873-7274e8b7dd19" />

As seen in screenshot above, MIT Press hyperlink needs new links for all 4 books. Hyperlink currently goes to MIT Press homepage.

New Atlas of Macroscopes link: https://mitpress.mit.edu/9780262049924/atlas-of-macroscopes/ 

New Atlas of Forecasts link: https://mitpress.mit.edu/9780262045957/atlas-of-forecasts/

New Atlas of Science link: 
https://mitpress.mit.edu/9780262014458/atlas-of-science/

New Atlas of Knowledge link: https://mitpress.mit.edu/9780262028813/atlas-of-knowledge/

All replacing https://mitpress.mit.edu/ on https://scimaps.org/books

